### PR TITLE
fix: 입력한 날짜와 변경된 날짜가 다른 버그 수정

### DIFF
--- a/src/_BacktestingPage/utils/mapToRequest.ts
+++ b/src/_BacktestingPage/utils/mapToRequest.ts
@@ -6,9 +6,11 @@ import type { BacktestFormValues } from "../types/backtestFormType";
 export function mapToBacktestRequest(
   values: BacktestFormSchema,
 ): BacktestFormValues {
+  const formatDate = (date: Date) => date.toLocaleDateString("sv-SE");
+
   return {
-    start_date: values.startDate.toISOString().slice(0, 10),
-    end_date: values.endDate.toISOString().slice(0, 10),
+    start_date: formatDate(values.startDate),
+    end_date: formatDate(values.endDate),
     initial_amount: values.initialAmount,
     rebalance_frequency: values.rebalanceFrequency,
   };


### PR DESCRIPTION
## 📌 작업 내용

- mapToBacktestRequest 함수에서 변환 시 하루 빠지는 날짜 오류 수정
- 예: 입력한 날짜가 2024-01-01일 때 변환 결과가 2023-12-31로 출력되던 문제 발생
- 기존 toISOString() 사용 시 UTC 기준으로 변환되어 발생한 이슈
- toLocaleDateString("sv-SE") 사용하여 현지 시간 기준으로 날짜 변환

## 🔧 해야 할 것 / 추가 작업

- [ ] Issue 항목 수행
