### PR TITLE
feat: backtest 페이지 라우팅

### DIFF
--- a/src/_MainPage/components/HeroSection.tsx
+++ b/src/_MainPage/components/HeroSection.tsx
@@ -2,6 +2,8 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { HERO_CONTENT } from "../mocks/heroContent";
 import React from "react";
+import { Link } from "react-router-dom";
+
 export default function HeroSection() {
   return (
     <div className="flex flex-col justify-center items-center py-20 sm:py-32 text-center">
@@ -22,11 +24,14 @@ export default function HeroSection() {
         ))}
       </p>
       <Button
+        asChild
         size="lg"
         className="bg-blue-500 hover:bg-blue-600 mt-10 px-9 py-6 rounded-full text-[1rem] text-white"
       >
-        {HERO_CONTENT.cta}
-        <ArrowRight className="ml-1 w-5 h-5" />
+        <Link to="/backtest">
+          {HERO_CONTENT.cta}
+          <ArrowRight className="ml-1 w-5 h-5" />
+        </Link>
       </Button>
     </div>
   );

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -18,7 +18,7 @@ export const routes: RouteObject[] = [
       { path: "markets", element: <MarketsPage /> },
       { path: "community", element: <CommunityPage /> },
       { path: "portfolio", element: <PortfolioPage /> },
-      { path: "backtesting", element: <BacktestingPage /> },
+      { path: "backtest", element: <BacktestingPage /> },
       { path: "login", element: <LoginPage /> },
     ],
   },


### PR DESCRIPTION
## 📌 작업 내용

- 메인페이지의 HeroSection에서 백테스트 바로가기 버튼 클릭시 /backtest 페이지로 이동
- 기존 /backtesting 이었던 경로를 /backtest로 수정

## 🔧 해야 할 것 / 추가 작업

- [ ] 
