### PR TITLE
[Refactor] React.FC 문법 제거

### DIFF
--- a/src/_CommunityPage/components/HotPosts.tsx
+++ b/src/_CommunityPage/components/HotPosts.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ThumbsUp } from "lucide-react";
 import type { Post } from "../types/postType";
 
@@ -6,7 +5,7 @@ interface HotPostsProps {
   posts: Post[];
 }
 
-const HotPosts: React.FC<HotPostsProps> = ({ posts }) => {
+const HotPosts = ({ posts }: HotPostsProps) => {
   // 추천수가 높은 순으로 정렬하여 상위 6개만 선택
   const popularPosts = [...posts].sort((a, b) => b.likes - a.likes).slice(0, 6);
 

--- a/src/_CommunityPage/components/PostList.tsx
+++ b/src/_CommunityPage/components/PostList.tsx
@@ -1,8 +1,7 @@
-import React from "react";
-import type { Post } from "../types/postType";
+import type { PostType } from "../types/postType";
 
 interface PostListProps {
-  posts: Post[];
+  posts: PostType[];
 }
 
 const formatDate = (dateString: string) => {
@@ -13,7 +12,7 @@ const formatDate = (dateString: string) => {
   return `${year}/${month}/${day}`;
 };
 
-const PostList: React.FC<PostListProps> = ({ posts }) => {
+const PostList = ({ posts }: PostListProps) => {
   return (
     <table className="w-full text-white border-collapse">
       <thead>

--- a/src/_CommunityPage/datas/mockPosts.ts
+++ b/src/_CommunityPage/datas/mockPosts.ts
@@ -1,6 +1,6 @@
-import type { Post } from "../types/postType";
+import type { PostType } from "../types/postType";
 
-export const MOCK_POSTS: Post[] = [
+export const MOCK_POSTS: PostType[] = [
   {
     id: 1,
     category: "자유",

--- a/src/_CommunityPage/types/postType.ts
+++ b/src/_CommunityPage/types/postType.ts
@@ -1,5 +1,5 @@
 // 게시글 데이터 타입
-export type Post = {
+export type PostType = {
   id: number;
   category: "자유" | "질문" | "정보 공유";
   title: string;
@@ -7,4 +7,16 @@ export type Post = {
   createdAt: string;
   views: number;
   likes: number;
+};
+
+// 인기 게시글용 타입 (기존 Post와 호환)
+export type Post = {
+  id: number;
+  rank: number;
+  title: string;
+  author: string;
+  ago: string;
+  comments: number;
+  likes: number;
+  stockName?: string;
 };

--- a/src/_MarketDetailPage/components/DetailItem.tsx
+++ b/src/_MarketDetailPage/components/DetailItem.tsx
@@ -6,11 +6,7 @@ interface DetailItemProps {
   className?: string;
 }
 
-const DetailItem: React.FC<DetailItemProps> = ({
-  label,
-  value,
-  className = "",
-}) => (
+const DetailItem = ({ label, value, className = "" }: DetailItemProps) => (
   <div className="flex justify-between items-center hover:bg-white/10 p-2 rounded-md text-sm transition-colors duration-200">
     <dt className="text-[1.2rem] text-gray-400">{label}</dt>
     <dd className={`text-[1.2rem] font-semibold ${className}`}>{value}</dd>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,16 +1,14 @@
-import React from "react";
-
 interface PaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
 }
 
-const Pagination: React.FC<PaginationProps> = ({
+const Pagination = ({
   currentPage,
   totalPages,
   onPageChange,
-}) => {
+}: PaginationProps) => {
   const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
 
   return (

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -1,6 +1,7 @@
 // src/pages/CommunityPage.tsx
-import React, { useState, useEffect, useMemo } from "react";
-import PostList, { type Post } from "../_CommunityPage/components/PostList";
+import { useState, useEffect, useMemo } from "react";
+import PostList from "../_CommunityPage/components/PostList";
+import type { PostType } from "../_CommunityPage/types/postType";
 import HotPosts from "../_CommunityPage/components/HotPosts";
 import Pagination from "../components/Pagination";
 import Title from "../components/Title";
@@ -9,9 +10,9 @@ import { MOCK_POSTS } from "../_CommunityPage/datas/mockPosts";
 const ITEMS_PER_PAGE = 10;
 const CATEGORIES = ["자유", "질문", "정보 공유"];
 
-const CommunityPage: React.FC = () => {
+const CommunityPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
-  const [posts, setPosts] = useState<Post[]>([]);
+  const [posts, setPosts] = useState<PostType[]>([]);
   const [activeCategory, setActiveCategory] = useState("자유");
 
   useEffect(() => {

--- a/src/pages/MarketDetailPage.tsx
+++ b/src/pages/MarketDetailPage.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import type { StockData } from "../_MarketDetailPage/types/stockDataType";
 import DetailItem from "@/_MarketDetailPage/components/DetailItem";
 import { sampleData } from "../_MarketDetailPage/datas/stockSample";
-const MarketDetailPage: React.FC = () => {
+const MarketDetailPage = () => {
   const [stockData, setStockData] = useState<StockData | null>(null);
 
   // 데이터 로딩 (실제로는 API 호출)

--- a/src/pages/MarketsPage.tsx
+++ b/src/pages/MarketsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import MarketList from "../_MarketsPage/components/MarketList";
 import { MOCK_DATA } from "../_MarketsPage/datas/MarketMockData";
 import type { MarketItem } from "../_MarketsPage/types/marketItem";
@@ -8,7 +8,7 @@ import Title from "../components/Title";
 const ITEMS_PER_PAGE = 10;
 const CATEGORIES = ["거래대금", "거래량", "급상승", "급하락", "인기"];
 
-const MarketsPage: React.FC = () => {
+const MarketsPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [marketData, setMarketData] = useState<MarketItem[]>([]);
   const [activeCategory, setActiveCategory] = useState("거래대금");


### PR DESCRIPTION
## 📌 작업 내용

- 리액트에서 타입스크립트 사용을 위해 선언했던 React.FC 문법을 제거하고 props type만 명시적으로 지정
